### PR TITLE
Fixes issues with running specs

### DIFF
--- a/spec/harvesting/client_spec.rb
+++ b/spec/harvesting/client_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe Harvesting::Client do
   let(:access_token) do
     "9999999.pt.abcdef"

--- a/spec/harvesting/models/time_entry_spec.rb
+++ b/spec/harvesting/models/time_entry_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe Harvesting::Models::TimeEntry, :vcr do
   let(:attrs) { Hash.new }
   let(:time_entry) { Harvesting::Models::TimeEntry.new(attrs) }

--- a/spec/harvesting_spec.rb
+++ b/spec/harvesting_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe Harvesting do
   it "has a version number" do
     expect(Harvesting::VERSION).not_to be nil


### PR DESCRIPTION
Without these changes, I was getting the output from below.

```
rake spec
/usr/local/bin/ruby -I/usr/local/bundle/gems/rspec-core-3.7.1/lib:/usr/local/bundle/gems/rspec-support-3.7.1/lib /usr/local/bundle/gems/rspec-core-3.7.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

An error occurred while loading ./spec/harvesting/client_spec.rb.
Failure/Error:
  RSpec.describe Harvesting::Client do
    let(:access_token) do
      "9999999.pt.abcdef"
    end
    let(:account_id) { "848484" }

    describe "#initialize" do
      context "when parameters are valid" do
        it "builds a client with a token and account" do
          Harvesting::Client.new(access_token: "foo", account_id: "bar")

NameError:
  uninitialized constant Harvesting::Client
# ./spec/harvesting/client_spec.rb:1:in `<top (required)>'

An error occurred while loading ./spec/harvesting/models/time_entry_spec.rb.
Failure/Error:
  RSpec.describe Harvesting::Models::TimeEntry, :vcr do
    let(:attrs) { Hash.new }
    let(:time_entry) { Harvesting::Models::TimeEntry.new(attrs) }
    let(:date) { "2018-05-14" }
    let(:started_time) { "8:00am" }
    let(:ended_time) { "9:00am" }
    let(:project_id) { '17367712' }
    let(:task_id) { '9713395' }
    let(:user_id) { '2108614' }

NameError:
  uninitialized constant Harvesting::Models
# ./spec/harvesting/models/time_entry_spec.rb:1:in `<top (required)>'


Finished in 0.00024 seconds (files took 0.16619 seconds to load)
0 examples, 0 failures, 2 errors occurred outside of examples
```