### PR TITLE
Do not require `byebug`

### DIFF
--- a/lib/harvesting/client.rb
+++ b/lib/harvesting/client.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "byebug"
 require "http"
 require "json"
 


### PR DESCRIPTION
Hey, this fixes #6. 

`byebug` is a development dep. So we should only require it when debugging issues. 

Please check it out.

Thanks! 