### PR TITLE
Add ability to fetch next page with persisted query parameters

### DIFF
--- a/fixtures/vcr_cassettes/Harvesting_Client_time_entries/when_iterating_over_the_next_page_with_custom_options_uses_the_custom_options_on_subsequent_page_fetches.yml
+++ b/fixtures/vcr_cassettes/Harvesting_Client_time_entries/when_iterating_over_the_next_page_with_custom_options_uses_the_custom_options_on_subsequent_page_fetches.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.harvestapp.com/v2/time_entries?from=2018-02-15&to=2018-04-27
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby Harvest API Sample
+      Authorization:
+      - Bearer 9999999.pt.abcdef
+      Harvest-Account-Id:
+      - '848484'
+      Connection:
+      - close
+      Host:
+      - api.harvestapp.com
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 23 Oct 2018 18:32:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '134'
+      Connection:
+      - close
+      Status:
+      - 401 Unauthorized
+      Www-Authenticate:
+      - Bearer realm="Rack::OAuth2 Protected Resources", error="invalid_token", error_description="The
+        access token provided is expired, revoked, malformed or invalid for other
+        reasons."
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 693e294652454cb9f160248b5d3dc082
+      X-Runtime:
+      - '0.013503'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":"invalid_token","error_description":"The access token provided
+        is expired, revoked, malformed or invalid for other reasons."}'
+    http_version: 
+  recorded_at: Tue, 23 Oct 2018 18:32:30 GMT
+recorded_with: VCR 4.0.0

--- a/lib/harvesting/client.rb
+++ b/lib/harvesting/client.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "pry"
 require "http"
 require "json"
 
@@ -42,16 +41,16 @@ module Harvesting
     end
 
     def projects(opts = {})
-      Harvesting::Models::Projects.new(get("projects", opts), client: self)
+      Harvesting::Models::Projects.new(get("projects", opts), opts, client: self)
     end
 
     def tasks(opts = {})
-      Harvesting::Models::Tasks.new(get("tasks", opts), client: self)
+      Harvesting::Models::Tasks.new(get("tasks", opts), opts, client: self)
     end
 
 
     def users(opts = {})
-      Harvesting::Models::Users.new(get("users", opts), client: self)
+      Harvesting::Models::Users.new(get("users", opts), opts, client: self)
     end
 
     def invoices

--- a/lib/harvesting/client.rb
+++ b/lib/harvesting/client.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+require "pry"
 require "http"
 require "json"
 
@@ -38,7 +38,7 @@ module Harvesting
     end
 
     def time_entries(opts = {})
-      Harvesting::Models::TimeEntries.new(get("time_entries", opts), client: self)
+      Harvesting::Models::TimeEntries.new(get("time_entries", opts), opts, client: self)
     end
 
     def projects(opts = {})

--- a/lib/harvesting/models/base.rb
+++ b/lib/harvesting/models/base.rb
@@ -22,7 +22,7 @@ module Harvesting
         opts.each do |attribute_name, model|
           attribute_name_string = attribute_name.to_s
           Harvesting::Models::Base.send :define_method, attribute_name_string do
-            @models[attribute_name_string] ||= model.new(@attributes[attribute_name_string] || {}, client: @client)
+            @models[attribute_name_string] ||= model.new(@attributes[attribute_name_string] || {}, client: harvest_client)
           end
         end
       end

--- a/lib/harvesting/models/projects.rb
+++ b/lib/harvesting/models/projects.rb
@@ -14,8 +14,9 @@ module Harvesting
 
       attr_reader :entries
 
-      def initialize(attrs, opts = {})
+      def initialize(attrs, query_opts = {}, opts = {})
         super(attrs.reject {|k,v| k == "projects" }, opts)
+        @query_opts = query_opts
         @api_page = attrs
         @entries = attrs["projects"].map do |entry|
           Project.new(entry, client: opts[:client])
@@ -35,10 +36,13 @@ module Harvesting
         total_entries
       end
 
+      def next_page_query_opts
+        @query_opts.merge(page: page + 1)
+      end
+
       def fetch_next_page
-        new_page = page + 1
-        @entries += harvest_client.projects(page: new_page).entries
-        @attributes['page'] = new_page
+        @entries += harvest_client.projects(next_page_query_opts).entries
+        @attributes['page'] = page + 1
       end
     end
   end

--- a/lib/harvesting/models/tasks.rb
+++ b/lib/harvesting/models/tasks.rb
@@ -14,8 +14,9 @@ module Harvesting
 
       attr_reader :entries
 
-      def initialize(attrs, opts = {})
+      def initialize(attrs, query_opts = {}, opts = {})
         super(attrs.reject {|k,v| k == "tasks" }, opts)
+        @query_opts = query_opts
         @api_page = attrs
         @entries = attrs["tasks"].map do |entry|
           Task.new(entry, client: opts[:client])
@@ -35,10 +36,13 @@ module Harvesting
         total_entries
       end
 
+      def next_page_query_opts
+        @query_opts.merge(page: page + 1)
+      end
+
       def fetch_next_page
-        new_page = page + 1
-        @entries += client.tasks(page: new_page).entries
-        @attributes['page'] = new_page
+        @entries += @client.tasks(next_page_query_opts).entries
+        @attributes['page'] = page + 1
       end
     end
   end

--- a/lib/harvesting/models/tasks.rb
+++ b/lib/harvesting/models/tasks.rb
@@ -41,7 +41,7 @@ module Harvesting
       end
 
       def fetch_next_page
-        @entries += @client.tasks(next_page_query_opts).entries
+        @entries += harvest_client.tasks(next_page_query_opts).entries
         @attributes['page'] = page + 1
       end
     end

--- a/lib/harvesting/models/time_entries.rb
+++ b/lib/harvesting/models/time_entries.rb
@@ -14,19 +14,15 @@ module Harvesting
 
       attr_reader :entries
 
-      def initialize(attrs, opts = {})
+      def initialize(attrs, query_opts = {}, opts = {})
         super(attrs.reject {|k,v| k == "time_entries" }, opts)
+        @query_opts = query_opts
         @api_page = attrs
         @entries = attrs["time_entries"].map do |entry|
           TimeEntry.new(entry, client: opts[:client])
         end
       end
 
-      # def each
-      #   @entries.each_with_index do |time_entry, index|
-      #     yield(time_entry)
-      #   end
-      # end
       def page
         @attributes['page']
       end
@@ -35,10 +31,13 @@ module Harvesting
         total_entries
       end
 
+      def next_page_query_opts
+        @query_opts.merge(page: page + 1)
+      end
+
       def fetch_next_page
-        new_page = page + 1
-        @entries += harvest_client.time_entries(page: new_page).entries
-        @attributes['page'] = new_page
+        @entries += harvest_client.time_entries(next_page_query_opts).entries
+        @attributes['page'] = page + 1
       end
     end
   end

--- a/lib/harvesting/models/users.rb
+++ b/lib/harvesting/models/users.rb
@@ -14,8 +14,9 @@ module Harvesting
 
       attr_reader :entries
 
-      def initialize(attrs, opts = {})
+      def initialize(attrs, query_opts = {}, opts = {})
         super(attrs.reject {|k,v| k == "users" }, opts)
+        @query_opts = query_opts
         @api_page = attrs
         @entries = attrs["users"].map do |entry|
           User.new(entry, client: opts[:client])
@@ -30,10 +31,13 @@ module Harvesting
         total_entries
       end
 
+      def next_page_query_opts
+        @query_opts.merge(page: page + 1)
+      end
+
       def fetch_next_page
-        new_page = page + 1
-        @entries += client.users(page: new_page).entries
-        @attributes['page'] = new_page
+        @entries += @client.users(next_page_query_opts).entries
+        @attributes['page'] = page + 1
       end
     end
   end

--- a/lib/harvesting/models/users.rb
+++ b/lib/harvesting/models/users.rb
@@ -36,7 +36,7 @@ module Harvesting
       end
 
       def fetch_next_page
-        @entries += @client.users(next_page_query_opts).entries
+        @entries += harvest_client.users(next_page_query_opts).entries
         @attributes['page'] = page + 1
       end
     end

--- a/spec/harvesting/client_spec.rb
+++ b/spec/harvesting/client_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Harvesting::Client, :vcr do
       end
 
       context 'with custom options' do
-        let(:result1) do
+        let(:page1_results) do
           entries = []
           100.times { entries.push({}) }
           {
@@ -169,7 +169,7 @@ RSpec.describe Harvesting::Client, :vcr do
           }
           end
 
-        let(:result2) do
+        let(:page2_results) do
           entries = []
           15.times { entries.push({}) }
           {
@@ -185,7 +185,7 @@ RSpec.describe Harvesting::Client, :vcr do
 
         it 'uses the custom options on subsequent page fetches' do
           stub_request(:get, /time_entries/).
-            to_return({ body: result1.to_json }, { body: result2.to_json })
+            to_return({ body: page1_results.to_json }, { body: page2_results.to_json })
 
           time_entries = subject.time_entries(from: "2018-02-15", to: "2018-04-27")
 
@@ -196,5 +196,155 @@ RSpec.describe Harvesting::Client, :vcr do
         end
       end
     end
+  end
+
+  describe "#users", :vcr do
+    subject { Harvesting::Client.new(access_token: access_token, account_id: account_id) }
+
+    context "when iterating over the next page" do
+
+      context 'with custom options' do
+        let(:page1_results) do
+          entries = []
+          100.times { entries.push({}) }
+          {
+              users: entries,
+              per_page: 100,
+              total_pages: 2,
+              total_entries: 115,
+              next_page: 2,
+              previous_page: nil,
+              page: 1
+          }
+        end
+
+        let(:page2_results) do
+          entries = []
+          15.times { entries.push({}) }
+          {
+              users: entries,
+              per_page: 100,
+              total_pages: 2,
+              total_entries: 115,
+              next_page: nil,
+              previous_page: 1,
+              page: 2
+          }
+        end
+
+        it 'uses the custom options on subsequent page fetches' do
+          stub_request(:get, /users/).
+              to_return({ body: page1_results.to_json }, { body: page2_results.to_json })
+
+          time_entries = subject.users(is_active: "true")
+
+          time_entries.each { |entry| }
+
+          expect(WebMock).to have_requested(:get, /users/).
+              with(query: {"is_active" => "true", "page" => "2"})
+        end
+      end
+    end
+
+  end
+
+  describe "#projects", :vcr do
+    subject { Harvesting::Client.new(access_token: access_token, account_id: account_id) }
+
+    context "when iterating over the next page" do
+
+      context 'with custom options' do
+        let(:page1_results) do
+          entries = []
+          100.times { entries.push({}) }
+          {
+              projects: entries,
+              per_page: 100,
+              total_pages: 2,
+              total_entries: 115,
+              next_page: 2,
+              previous_page: nil,
+              page: 1
+          }
+        end
+
+        let(:page2_results) do
+          entries = []
+          15.times { entries.push({}) }
+          {
+              projects: entries,
+              per_page: 100,
+              total_pages: 2,
+              total_entries: 115,
+              next_page: nil,
+              previous_page: 1,
+              page: 2
+          }
+        end
+
+        it 'uses the custom options on subsequent page fetches' do
+          stub_request(:get, /projects/).
+              to_return({ body: page1_results.to_json }, { body: page2_results.to_json })
+
+          time_entries = subject.projects(is_active: "true")
+
+          time_entries.each { |entry| }
+
+          expect(WebMock).to have_requested(:get, /projects/).
+              with(query: {"is_active" => "true", "page" => "2"})
+        end
+      end
+    end
+
+  end
+
+  describe "#tasks", :vcr do
+    subject { Harvesting::Client.new(access_token: access_token, account_id: account_id) }
+
+    context "when iterating over the next page" do
+
+      context 'with custom options' do
+        let(:page1_results) do
+          entries = []
+          100.times { entries.push({}) }
+          {
+              tasks: entries,
+              per_page: 100,
+              total_pages: 2,
+              total_entries: 115,
+              next_page: 2,
+              previous_page: nil,
+              page: 1
+          }
+        end
+
+        let(:page2_results) do
+          entries = []
+          15.times { entries.push({}) }
+          {
+              tasks: entries,
+              per_page: 100,
+              total_pages: 2,
+              total_entries: 115,
+              next_page: nil,
+              previous_page: 1,
+              page: 2
+          }
+        end
+
+        it 'uses the custom options on subsequent page fetches' do
+          stub_request(:get, /tasks/).
+              to_return({ body: page1_results.to_json }, { body: page2_results.to_json })
+
+          time_entries = subject.tasks(is_active: "true")
+
+          time_entries.each { |entry| }
+
+          expect(WebMock).to have_requested(:get, /tasks/).
+              with(query: {"is_active" => "true", "page" => "2"})
+        end
+      end
+    end
+
   end
 end

--- a/spec/harvesting/client_spec.rb
+++ b/spec/harvesting/client_spec.rb
@@ -153,6 +153,48 @@ RSpec.describe Harvesting::Client, :vcr do
 
         expect(ids.size).to eq(time_entries.size)
       end
+
+      context 'with custom options' do
+        let(:result1) do
+          entries = []
+          100.times { entries.push({}) }
+          {
+              time_entries: entries,
+              per_page: 100,
+              total_pages: 2,
+              total_entries: 115,
+              next_page: 2,
+              previous_page: nil,
+              page: 1
+          }
+          end
+
+        let(:result2) do
+          entries = []
+          15.times { entries.push({}) }
+          {
+              time_entries: entries,
+              per_page: 100,
+              total_pages: 2,
+              total_entries: 115,
+              next_page: nil,
+              previous_page: 1,
+              page: 2
+          }
+        end
+
+        it 'uses the custom options on subsequent page fetches' do
+          stub_request(:get, /time_entries/).
+            to_return({ body: result1.to_json }, { body: result2.to_json })
+
+          time_entries = subject.time_entries(from: "2018-02-15", to: "2018-04-27")
+
+          time_entries.each { |entry| }
+
+          expect(WebMock).to have_requested(:get, /time_entries/).
+            with(query: {"from" => "2018-02-15", "page" => "2", "to" => "2018-04-27"})
+        end
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require "bundler/setup"
 require 'dotenv/load'
 require "harvesting"
 require "webmock"
+require "webmock/rspec"
 require "vcr"
 
 VCR.configure do |config|


### PR DESCRIPTION
When requesting a new page of results (Not page 1), the query parameters are not persisted which leads to incorrect results. This PR intends to persist the initial query parameters that were correctly passed into the API request for the first page, along to the subsequent API requests for the rest of the pages of results.