### PR TITLE
Dynamically generate methods on concrete classes only

### DIFF
--- a/lib/harvesting/models/base.rb
+++ b/lib/harvesting/models/base.rb
@@ -12,7 +12,7 @@ module Harvesting
 
       def self.attributed(*attribute_names)
         attribute_names.each do |attribute_name|
-          Harvesting::Models::Base.send :define_method, attribute_name.to_s do
+          define_method(attribute_name) do
             @attributes[__method__.to_s]
           end
         end

--- a/lib/harvesting/models/project.rb
+++ b/lib/harvesting/models/project.rb
@@ -11,6 +11,7 @@ module Harvesting
                  :hourly_rate,
                  :budget,
                  :budget_by,
+                 :budget_is_monthly,
                  :notify_when_over_budget,
                  :over_budget_notification_percentage,
                  :over_budget_notification_date,

--- a/lib/harvesting/models/time_entry.rb
+++ b/lib/harvesting/models/time_entry.rb
@@ -5,8 +5,6 @@ module Harvesting
                  :spent_date,
                  :hours,
                  :notes,
-                 :created_at,
-                 :updated_at,
                  :is_locked,
                  :locked_reason,
                  :is_closed,
@@ -19,9 +17,10 @@ module Harvesting
                  :budgeted,
                  :billable_rate,
                  :cost_rate,
-                 :task_id,
                  :invoice,
                  :external_reference,
+                 :created_at,
+                 :updated_at,
                  :user_assignment # temporarily return the hash itself until the model is added
 
       modeled project: Project,
@@ -29,6 +28,7 @@ module Harvesting
               task: Task,
               client: Client,
               task_assignment: TaskAssignment
+
 
       def path
         id.nil? ? "time_entries" : "time_entries/#{id}"

--- a/lib/harvesting/models/user.rb
+++ b/lib/harvesting/models/user.rb
@@ -7,19 +7,21 @@ module Harvesting
                  :email,
                  :telephone,
                  :timezone,
-                 :weekly_capacity,
                  :has_access_to_all_future_projects,
                  :is_contractor,
                  :is_admin,
                  :is_project_manager,
                  :can_see_rates,
-                 :can_create_projects,
                  :can_create_invoices,
+                 :can_create_projects,
                  :is_active,
-                 :created_at,
-                 :updated_at,
+                 :weekly_capacity,
+                 :default_hourly_rate,
+                 :cost_rate,
                  :roles,
-                 :avatar_url
+                 :avatar_url,
+                 :created_at,
+                 :updated_at
 
       def path
         id.nil? ? "users" : "users/#{id}"

--- a/spec/harvesting/client_spec.rb
+++ b/spec/harvesting/client_spec.rb
@@ -130,16 +130,16 @@ RSpec.describe Harvesting::Client, :vcr do
         expect(time_entries.size).to eq(119)
       end
 
-      it 'time entries provide access to associated user' do
+      it 'provide access to associated user' do
         first_time_entry = time_entries.first
-        expect(first_time_entry.user.id).to be
-        expect(first_time_entry.user.name).to be
+        expect(first_time_entry.user).to respond_to(:id)
+        expect(first_time_entry.user).to respond_to(:first_name)
       end
 
-      it 'time entires provide access to associated task' do
+      it 'provide access to associated task' do
         first_time_entry = time_entries.first
-        expect(first_time_entry.task.id).to be
-        expect(first_time_entry.task.name).to eq('Coding')
+        expect(first_time_entry.task).to respond_to(:id)
+        expect(first_time_entry.task).to respond_to(:name)
       end
 
       it "correctly accesses all pages" do

--- a/spec/harvesting/models/time_entry_spec.rb
+++ b/spec/harvesting/models/time_entry_spec.rb
@@ -129,5 +129,13 @@ RSpec.describe Harvesting::Models::TimeEntry, :vcr do
     it 'does not throw when parent is nil' do
       expect(time_entry.user.id).to eq(nil)
     end
+
+    it 'creates accessors on instances of this class' do
+      expect(time_entry).to respond_to(:spent_date)
+    end
+
+    it 'does not create accessors on instances of other classes' do
+      expect(time_entry.class.superclass.new(attrs)).not_to respond_to(:spent_date)
+    end
   end
 end


### PR DESCRIPTION
Avoid creating public methods on instances of the base class itself, so that derived types don't interfere with each other