### PR TITLE
Proposal: The `client` keyword is confusing -- Let's fix it

### DIFF
--- a/lib/harvesting/client.rb
+++ b/lib/harvesting/client.rb
@@ -28,47 +28,47 @@ module Harvesting
 
     # @return [Harvesting::Models::User]
     def me
-      Harvesting::Models::User.new(get("users/me"), client: self)
+      Harvesting::Models::User.new(get("users/me"), harvest_client: self)
     end
 
     # @return [Array<Harvesting::Models::Client>]
     def clients
       get("clients")["clients"].map do |result|
-        Harvesting::Models::Client.new(result, client: self)
+        Harvesting::Models::Client.new(result, harvest_client: self)
       end
     end
 
     # @return [Array<Harvesting::Models::Contact>]
     def contacts
       get("contacts")["contacts"].map do |result|
-        Harvesting::Models::Contact.new(result, client: self)
+        Harvesting::Models::Contact.new(result, harvest_client: self)
       end
     end
 
     # @return [Harvesting::Models::TimeEntries]
     def time_entries(opts = {})
-      Harvesting::Models::TimeEntries.new(get("time_entries", opts), opts, client: self)
+      Harvesting::Models::TimeEntries.new(get("time_entries", opts), opts, harvest_client: self)
     end
 
     # @return [Harvesting::Models::Projects]
     def projects(opts = {})
-      Harvesting::Models::Projects.new(get("projects", opts), opts, client: self)
+      Harvesting::Models::Projects.new(get("projects", opts), opts, harvest_client: self)
     end
 
     # @return [Harvesting::Models::Tasks]
     def tasks(opts = {})
-      Harvesting::Models::Tasks.new(get("tasks", opts), opts, client: self)
+      Harvesting::Models::Tasks.new(get("tasks", opts), opts, harvest_client: self)
     end
 
     # @return [Harvesting::Models::Users]
     def users(opts = {})
-      Harvesting::Models::Users.new(get("users", opts), opts, client: self)
+      Harvesting::Models::Users.new(get("users", opts), opts, harvest_client: self)
     end
 
     # @return [Array<Harvesting::Models::Invoice>]
     def invoices
       get("invoices")["invoices"].map do |result|
-        Harvesting::Models::Invoice.new(result, client: self)
+        Harvesting::Models::Invoice.new(result, harvest_client: self)
       end
     end
 
@@ -76,14 +76,14 @@ module Harvesting
     def user_assignments(opts = {})
       project_id = opts.delete(:project_id)
       path = project_id.nil? ? "user_assignments" : "projects/#{project_id}/user_assignments"
-      Harvesting::Models::ProjectUserAssignments.new(get(path, opts), opts, client: self)
+      Harvesting::Models::ProjectUserAssignments.new(get(path, opts), opts, harvest_client: self)
     end
 
     # @return [Harvesting::Models::ProjectTaskAssignments]
     def task_assignments(opts = {})
       project_id = opts.delete(:project_id)
       path = project_id.nil? ? "task_assignments" : "projects/#{project_id}/task_assignments"
-      Harvesting::Models::ProjectTaskAssignments.new(get(path, opts), opts, client: self)
+      Harvesting::Models::ProjectTaskAssignments.new(get(path, opts), opts, harvest_client: self)
     end
 
     # Creates an `entity` in your Harvest account.

--- a/lib/harvesting/models/base.rb
+++ b/lib/harvesting/models/base.rb
@@ -9,7 +9,7 @@ module Harvesting
       def initialize(attrs, opts = {})
         @models = {}
         @attributes = attrs.dup
-        @harvest_client = opts[:client] || Harvesting::Client.new(opts)
+        @harvest_client = opts[:harvest_client] || Harvesting::Client.new(opts)
       end
 
       # It calls `create` or `update` depending on the record's ID. If the ID
@@ -56,7 +56,7 @@ module Harvesting
       #
       # @return [Harvesting::Models::Base]
       def fetch
-        self.class.new(@harvest_client.get(path), client: @harvest_client)
+        self.class.new(@harvest_client.get(path), harvest_client: @harvest_client)
       end
 
       # Retrieves an instance of the object by ID
@@ -65,7 +65,7 @@ module Harvesting
       # @param opts [Hash] options to pass along to the `Harvesting::Client`
       #   instance
       def self.get(id, opts = {})
-        client = opts[:client] || Harvesting::Client.new(opts)
+        client = opts[:harvest_client] || Harvesting::Client.new(opts)
         self.new({ 'id' => id }, opts).fetch
       end
 
@@ -109,7 +109,7 @@ module Harvesting
         opts.each do |attribute_name, model|
           attribute_name_string = attribute_name.to_s
           Harvesting::Models::Base.send :define_method, attribute_name_string do
-            @models[attribute_name_string] ||= model.new(@attributes[attribute_name_string] || {}, client: harvest_client)
+            @models[attribute_name_string] ||= model.new(@attributes[attribute_name_string] || {}, harvest_client: harvest_client)
           end
         end
       end

--- a/lib/harvesting/models/project_task_assignments.rb
+++ b/lib/harvesting/models/project_task_assignments.rb
@@ -4,7 +4,7 @@ module Harvesting
       def initialize(attrs, query_opts = {}, opts = {})
         super(attrs.reject {|k,v| k == "task_assignments" }, query_opts, opts)
         @entries = attrs["task_assignments"].map do |entry|
-          ProjectTaskAssignment.new(entry, client: opts[:client])
+          ProjectTaskAssignment.new(entry, harvest_client: opts[:harvest_client])
         end
       end
 

--- a/lib/harvesting/models/project_user_assignments.rb
+++ b/lib/harvesting/models/project_user_assignments.rb
@@ -5,7 +5,7 @@ module Harvesting
       def initialize(attrs, query_opts = {}, opts = {})
         super(attrs.reject {|k,v| k == "user_assignments" }, query_opts, opts)
         @entries = attrs["user_assignments"].map do |entry|
-          ProjectUserAssignment.new(entry, client: opts[:client])
+          ProjectUserAssignment.new(entry, harvest_client: opts[:harvest_client])
         end
       end
 

--- a/lib/harvesting/models/projects.rb
+++ b/lib/harvesting/models/projects.rb
@@ -5,7 +5,7 @@ module Harvesting
       def initialize(attrs, query_opts = {}, opts = {})
         super(attrs.reject {|k,v| k == "projects" }, query_opts, opts)
         @entries = attrs["projects"].map do |entry|
-          Project.new(entry, client: opts[:client])
+          Project.new(entry, harvest_client: opts[:harvest_client])
         end
       end
 

--- a/lib/harvesting/models/tasks.rb
+++ b/lib/harvesting/models/tasks.rb
@@ -5,7 +5,7 @@ module Harvesting
       def initialize(attrs, query_opts = {}, opts = {})
         super(attrs.reject {|k,v| k == "tasks" }, query_opts, opts)
         @entries = attrs["tasks"].map do |entry|
-          Task.new(entry, client: opts[:client])
+          Task.new(entry, harvest_client: opts[:harvest_client])
         end
       end
 

--- a/lib/harvesting/models/time_entries.rb
+++ b/lib/harvesting/models/time_entries.rb
@@ -5,7 +5,7 @@ module Harvesting
       def initialize(attrs, query_opts = {}, opts = {})
         super(attrs.reject {|k,v| k == "time_entries" }, query_opts, opts)
         @entries = attrs["time_entries"].map do |entry|
-          TimeEntry.new(entry, client: opts[:client])
+          TimeEntry.new(entry, harvest_client: opts[:harvest_client])
         end
       end
 

--- a/lib/harvesting/models/users.rb
+++ b/lib/harvesting/models/users.rb
@@ -5,7 +5,7 @@ module Harvesting
       def initialize(attrs, query_opts = {}, opts = {})
         super(attrs.reject {|k,v| k == "users" }, query_opts, opts)
         @entries = attrs["users"].map do |entry|
-          User.new(entry, client: opts[:client])
+          User.new(entry, harvest_client: opts[:harvest_client])
         end
       end
 

--- a/spec/harvesting/harvest_data_setup.rb
+++ b/spec/harvesting/harvest_data_setup.rb
@@ -98,7 +98,7 @@ RSpec.shared_context "harvest data setup" do
         "last_name" => "Smith",
         "email" => "john.smith@example.com"
       },
-      client: harvest_client
+      harvest_client: harvest_client
     )
     john_smith.save
     john_smith
@@ -111,7 +111,7 @@ RSpec.shared_context "harvest data setup" do
         "last_name" => "Doe",
         "email" => "jane.doe@example.com"
       },
-      client: harvest_client
+      harvest_client: harvest_client
     )
     jane_doe.save
     jane_doe
@@ -123,7 +123,7 @@ RSpec.shared_context "harvest data setup" do
         {
           "name" => "Pepe"
         },
-        client: harvest_client
+        harvest_client: harvest_client
       )
       pepe.save
       pepe
@@ -136,7 +136,7 @@ RSpec.shared_context "harvest data setup" do
         {
           "name" => "Toto"
         },
-        client: harvest_client
+        harvest_client: harvest_client
       )
       toto.save
       toto
@@ -159,7 +159,7 @@ RSpec.shared_context "harvest data setup" do
               "id" => client_pepe.id.to_s
           }
         },
-        client: harvest_client
+        harvest_client: harvest_client
       )
       jon_snow.save
       jon_snow
@@ -178,7 +178,7 @@ RSpec.shared_context "harvest data setup" do
           "bill_by" => "Tasks",
           "budget_by" => "person"
         },
-        client: harvest_client
+        harvest_client: harvest_client
       )
       castle_building.save
       castle_building
@@ -197,7 +197,7 @@ RSpec.shared_context "harvest data setup" do
           "bill_by" => "Tasks",
           "budget_by" => "person"
         },
-        client: harvest_client
+        harvest_client: harvest_client
       )
       castle_building.save
       castle_building
@@ -210,7 +210,7 @@ RSpec.shared_context "harvest data setup" do
         {
           "name" => "Coding"
         },
-        client: harvest_client
+        harvest_client: harvest_client
       )
       coding.save
       coding
@@ -222,7 +222,7 @@ RSpec.shared_context "harvest data setup" do
       {
         "name" => "Writing"
       },
-      client: harvest_client
+      harvest_client: harvest_client
     )
     writing.save
     writing
@@ -239,7 +239,7 @@ RSpec.shared_context "harvest data setup" do
                 "id" => task_coding.id.to_s
             }
         },
-        client: harvest_client
+        harvest_client: harvest_client
       )
       castle_building_coding.save
       castle_building_coding
@@ -256,7 +256,7 @@ RSpec.shared_context "harvest data setup" do
               "id" => task_writing.id.to_s
           }
       },
-      client: harvest_client
+      harvest_client: harvest_client
     )
     road_building_writing.save
     road_building_writing
@@ -273,7 +273,7 @@ RSpec.shared_context "harvest data setup" do
             "id" => user_john_smith.id.to_s
           }
         },
-        client: harvest_client
+        harvest_client: harvest_client
       )
       project_assignment.save
       project_assignment
@@ -290,7 +290,7 @@ RSpec.shared_context "harvest data setup" do
           "id" => user_jane_doe.id.to_s
         }
       },
-      client: harvest_client
+      harvest_client: harvest_client
     )
     project_assignment.save
     project_assignment
@@ -306,7 +306,7 @@ RSpec.shared_context "harvest data setup" do
               "id" => client_toto.id.to_s
           }
         },
-        client: harvest_client
+        harvest_client: harvest_client
       )
       cersei_lannister.save
       cersei_lannister
@@ -328,7 +328,7 @@ RSpec.shared_context "harvest data setup" do
             "spent_date" => (Time.now - one_day * (iteration + 1)).iso8601.to_s,
             "hours" => 6.to_s
           },
-          client: harvest_client
+          harvest_client: harvest_client
         )
         time.save
         result << time

--- a/spec/harvesting/models/time_entry_spec.rb
+++ b/spec/harvesting/models/time_entry_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Harvesting::Models::TimeEntry, :vcr do
   include_context "harvest data setup"
 
   let(:attrs) { Hash.new }
-  let(:time_entry) { Harvesting::Models::TimeEntry.new(attrs, client: harvest_client) }
+  let(:time_entry) { Harvesting::Models::TimeEntry.new(attrs, harvest_client: harvest_client) }
   let(:date) { "2018-05-14" }
   let(:started_time) { "8:00am" }
   let(:ended_time) { "9:00am" }


### PR DESCRIPTION
Hey @mscottford,

The `client` keyword is confusing because there is a `Client` model and a Harvest `Client` (as in API client)

So we should probably rename the `client` key as `harvest_client` to avoid confusion.

What do you think?

Thanks,
Ernesto